### PR TITLE
Use oauth session for user calls; support for throttling calls

### DIFF
--- a/betterreads/client.py
+++ b/betterreads/client.py
@@ -190,7 +190,7 @@ class GoodreadsClient:
             "%s/%s/comments" % (comment_type, resource_id), {"format": "xml"}
         )
         return [
-            GoodreadsComment(comment_dict)
+            GoodreadsComment(comment_dict, self)
             for comment_dict in resp["comments"]["comment"]
         ]
 

--- a/betterreads/comment.py
+++ b/betterreads/comment.py
@@ -6,8 +6,9 @@ from betterreads.user import GoodreadsUser
 class GoodreadsComment:
     """Goodreads comment class"""
 
-    def __init__(self, comment_dict):
+    def __init__(self, comment_dict, client):
         self._comment_dict = comment_dict
+        self._client = client
 
     @property
     def gid(self):
@@ -22,7 +23,7 @@ class GoodreadsComment:
     @property
     def user(self):
         """User that made the comment"""
-        return GoodreadsUser(self._comment_dict["user"], self)
+        return GoodreadsUser(self._comment_dict["user"], self._client)
 
     @property
     def created_at(self):

--- a/betterreads/request.py
+++ b/betterreads/request.py
@@ -2,6 +2,8 @@ import requests
 import xmltodict
 import json
 
+from betterreads.request_util import throttle
+
 
 class GoodreadsRequestException(Exception):
     def __init__(self, error_msg, url):
@@ -21,6 +23,7 @@ class GoodreadsRequest:
         self.path = path
         self.req_format = req_format
 
+    @throttle
     def request(self):
         resp = requests.get(self.host + self.path, params=self.params)
         if resp.status_code != 200:

--- a/betterreads/request_util.py
+++ b/betterreads/request_util.py
@@ -1,0 +1,41 @@
+"""
+The API TOS limits to a request rate of 1 request per second per application. This decorator
+can enforce that limit for single-threaded applications by setting the environmental
+variable `GOODREADS_REQUEST_WAIT_MIN=1`. When not set, this decorator does nothing.
+"""
+import functools
+import os
+import time
+
+GOODREADS_REQUEST_WAIT_MIN = float(os.environ.get("GOODREADS_REQUEST_WAIT_MIN", 0.0))
+
+
+class ThrottleDecorator:
+
+    TIME_DELTA = 0.001
+
+    def __init__(self, request_wait_min=GOODREADS_REQUEST_WAIT_MIN):
+        self.request_wait_min = request_wait_min
+        # Initialize last_call so that the first call will always go through quickly.
+        self.last_call = time.time() - self.request_wait_min
+
+    def __call__(self, fn):
+        @functools.wraps(fn)
+        def throttled(*args, **kwargs):
+            if self.request_wait_min > 0:
+                # Wait until a call is allowed.
+                self._wait_until_okay_to_call()
+                resp = fn(*args, **kwargs)
+                self.last_call = time.time()
+                return resp
+            else:
+                return fn(*args, **kwargs)
+
+        return throttled
+
+    def _wait_until_okay_to_call(self):
+        while time.time() - self.last_call < self.request_wait_min:
+            time.sleep(self.TIME_DELTA)
+
+
+throttle = ThrottleDecorator()

--- a/betterreads/session.py
+++ b/betterreads/session.py
@@ -1,6 +1,8 @@
 from rauth.service import OAuth1Service, OAuth1Session
 import xmltodict
 
+from betterreads.request_util import throttle
+
 
 class GoodreadsSession:
     """Handle OAuth sessions"""
@@ -51,6 +53,7 @@ class GoodreadsSession:
             access_token_secret=self.access_token_secret,
         )
 
+    @throttle
     def get(self, path, params=None):
         """OAuth get request"""
         if not params:


### PR DESCRIPTION
## What is in this PR?

Select all that apply

- [X] Bugfix

- [X] New feature

- [ ] Documentation improvements

- [ ] Improved test coverage

- [ ] Other: (Please specify)

## Issue

This might address the issue here, though that was not my goal: https://github.com/thejessleigh/betterreads/issues/34

## Abstract

1. Use the oauth session for user calls when available.
2. Add support for throttling of API requests to stay within the API TOS (1 second between requests).

## Dependency updates

None

## Good Citizenship

- [X] I have updated any relevant tests and the test suite is passing

I could use some help thinking through the right way to test the oauth session user calls. I don't believe there is currently an authentication test. I tested for my own user after authorizing my app, so it works in that one case!

- [X] I have updated any relevant documentation

- [X] I have run the pre-commit hooks for this repository's designated code styles
